### PR TITLE
ci: point GitHub Actions at Consensys-Incorporated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,4 +17,4 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Build
-        uses: ConsenSys/github-actions/docs-build@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main
+        uses: Consensys-Incorporated/github-actions/docs-build@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,4 +17,4 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Build
-        uses: Consensys-Incorporated/github-actions/docs-build@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main
+        uses: Consensys-Incorporated/github-actions/docs-build@28327992dc4f4eeeee937abbaebf63f00f4f6068 # main

--- a/.github/workflows/case.yml
+++ b/.github/workflows/case.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Case check action
-        uses: Consensys-Incorporated/github-actions/docs-case-check@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main
+        uses: Consensys-Incorporated/github-actions/docs-case-check@28327992dc4f4eeeee937abbaebf63f00f4f6068 # main
         with:
           DOC_DIR: ${{ matrix.folder }}
           SKIP_TEST: true

--- a/.github/workflows/case.yml
+++ b/.github/workflows/case.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Case check action
-        uses: ConsenSys/github-actions/docs-case-check@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main
+        uses: Consensys-Incorporated/github-actions/docs-case-check@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main
         with:
           DOC_DIR: ${{ matrix.folder }}
           SKIP_TEST: true

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -14,6 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: LinkCheck
-        uses: ConsenSys/github-actions/docs-link-check@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main
+        uses: Consensys-Incorporated/github-actions/docs-link-check@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main
         with:
           CONFIG_FILE: .linkspector.yml

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -14,6 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: LinkCheck
-        uses: Consensys-Incorporated/github-actions/docs-link-check@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main
+        uses: Consensys-Incorporated/github-actions/docs-link-check@28327992dc4f4eeeee937abbaebf63f00f4f6068 # main
         with:
           CONFIG_FILE: .linkspector.yml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Lint code
-        uses: Consensys-Incorporated/github-actions/docs-lint-all@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main
+        uses: Consensys-Incorporated/github-actions/docs-lint-all@28327992dc4f4eeeee937abbaebf63f00f4f6068 # main
 
       - name: Lint markdown
-        uses: Consensys-Incorporated/github-actions/docs-lint-markdown@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main
+        uses: Consensys-Incorporated/github-actions/docs-lint-markdown@28327992dc4f4eeeee937abbaebf63f00f4f6068 # main

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Lint code
-        uses: ConsenSys/github-actions/docs-lint-all@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main
+        uses: Consensys-Incorporated/github-actions/docs-lint-all@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main
 
       - name: Lint markdown
-        uses: ConsenSys/github-actions/docs-lint-markdown@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main
+        uses: Consensys-Incorporated/github-actions/docs-lint-markdown@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,7 @@
           uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
         - name: LinkCheck
-          uses: Consensys-Incorporated/github-actions/docs-link-check@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main
+          uses: Consensys-Incorporated/github-actions/docs-link-check@28327992dc4f4eeeee937abbaebf63f00f4f6068 # main
           with:
             CONFIG_FILE: .linkspector.yml
 
@@ -39,7 +39,7 @@
             fi
 
         - name: Slack Notification
-          uses: Consensys-Incorporated/github-actions/slack-notify@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main
+          uses: Consensys-Incorporated/github-actions/slack-notify@28327992dc4f4eeeee937abbaebf63f00f4f6068 # main
           env:
             SLACK_CHANNEL: doc-ci-alerts
             SLACK_COLOR: danger

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,7 @@
           uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
         - name: LinkCheck
-          uses: ConsenSys/github-actions/docs-link-check@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main
+          uses: Consensys-Incorporated/github-actions/docs-link-check@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main
           with:
             CONFIG_FILE: .linkspector.yml
 
@@ -39,7 +39,7 @@
             fi
 
         - name: Slack Notification
-          uses: ConsenSys/github-actions/slack-notify@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main
+          uses: Consensys-Incorporated/github-actions/slack-notify@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main
           env:
             SLACK_CHANNEL: doc-ci-alerts
             SLACK_COLOR: danger

--- a/.github/workflows/renovatebot.yml
+++ b/.github/workflows/renovatebot.yml
@@ -53,7 +53,7 @@ jobs:
           echo "RENOVATE_MINIMUM_RELEASE_AGE=$MINIMUM_RELEASE_AGE days" >> $GITHUB_ENV
 
       - name: Run renovatebot
-        uses: ConsenSys/github-actions/renovatebot@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main
+        uses: Consensys-Incorporated/github-actions/renovatebot@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main
         with:
           GH_APP_ID: ${{ secrets.GH_APP_ID }}
           GH_PRIVATE_KEY: ${{ secrets.GH_PRIVATE_KEY }}

--- a/.github/workflows/renovatebot.yml
+++ b/.github/workflows/renovatebot.yml
@@ -53,7 +53,7 @@ jobs:
           echo "RENOVATE_MINIMUM_RELEASE_AGE=$MINIMUM_RELEASE_AGE days" >> $GITHUB_ENV
 
       - name: Run renovatebot
-        uses: Consensys-Incorporated/github-actions/renovatebot@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main
+        uses: Consensys-Incorporated/github-actions/renovatebot@28327992dc4f4eeeee937abbaebf63f00f4f6068 # main
         with:
           GH_APP_ID: ${{ secrets.GH_APP_ID }}
           GH_PRIVATE_KEY: ${{ secrets.GH_PRIVATE_KEY }}

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Vale
-        uses: Consensys/github-actions/docs-spelling-check@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main
+        uses: Consensys-Incorporated/github-actions/docs-spelling-check@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main
         with:
           FILEPATHS: "docs"
 

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Vale
-        uses: Consensys-Incorporated/github-actions/docs-spelling-check@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main
+        uses: Consensys-Incorporated/github-actions/docs-spelling-check@28327992dc4f4eeeee937abbaebf63f00f4f6068 # main
         with:
           FILEPATHS: "docs"
 

--- a/.github/workflows/trivy-cache.yml
+++ b/.github/workflows/trivy-cache.yml
@@ -16,4 +16,4 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Trivy Cache
-        uses: Consensys-Incorporated/github-actions/trivy-update-cache@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main
+        uses: Consensys-Incorporated/github-actions/trivy-update-cache@28327992dc4f4eeeee937abbaebf63f00f4f6068 # main

--- a/.github/workflows/trivy-cache.yml
+++ b/.github/workflows/trivy-cache.yml
@@ -16,4 +16,4 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Trivy Cache
-        uses: ConsenSys/github-actions/trivy-update-cache@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main
+        uses: Consensys-Incorporated/github-actions/trivy-update-cache@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Trivy
-        uses: Consensys-Incorporated/github-actions/trivy@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main
+        uses: Consensys-Incorporated/github-actions/trivy@28327992dc4f4eeeee937abbaebf63f00f4f6068 # main

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Trivy
-        uses: ConsenSys/github-actions/trivy@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main
+        uses: Consensys-Incorporated/github-actions/trivy@979fb3e168f8f7af5e59378a02420c8f6fc4a6a9 # main


### PR DESCRIPTION
The shared docs actions repo moved off Consensys, so CI was failing to resolve Consensys/github-actions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only path updates with no application or runtime behavior changes; main risk is transient CI failure if the new org or pin is misconfigured.
> 
> **Overview**
> Updates every workflow that depended on the shared **ConsenSys/github-actions** repo so they resolve **Consensys-Incorporated/github-actions** instead, fixing CI when those actions no longer exist under the old org.
> 
> The change is the same across **build**, **case**, **links**, **lint**, **spelling**, **trivy**, **trivy-cache**, **nightly** (link check + Slack notify), and **renovatebot**: only the `uses:` owner/org and pinned ref move from `979fb3e…` to `28327992…` on `main`. Workflow triggers, inputs, secrets, and checkout pins are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38388d9cb226b16ed379eb7ed0d0b19b5893b961. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->