### PR TITLE
docs: update GitHub organization references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Web3Signer documentation
 
 This repository contains the source for the
-[Web3Signer](https://github.com/Consensys/web3signer) documentation site.
+[Web3Signer](https://github.com/Consensys-Incorporated/web3signer) documentation site.
 It is built with Docusaurus and published at
 [docs.web3signer.consensys.io](https://docs.web3signer.consensys.io/).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Web3Signer documentation
 
 Web3Signer is a transaction signing application to be used with a web3 provider.
-The software sources are hosted in the [Web3Signer repository](https://github.com/Consensys/web3signer).
+The software sources are hosted in the [Web3Signer repository](https://github.com/Consensys-Incorporated/web3signer).
 
 This documentation repository is built using [Docusaurus](https://docusaurus.io/), and the doc
 site is published at [`docs.web3signer.consensys.io`](https://docs.web3signer.consensys.io/).

--- a/docs/get-started/build-from-source.md
+++ b/docs/get-started/build-from-source.md
@@ -25,7 +25,7 @@ Web3Signer requires Java 25 or later releases.
 Clone the `Consensys/web3signer` repository:
 
 ```bash
-git clone --recursive https://github.com/Consensys/web3signer.git
+git clone --recursive https://github.com/Consensys-Incorporated/web3signer.git
 ```
 
 ### Build Web3Signer
@@ -68,7 +68,7 @@ bin/web3signer --help
 Clone the `Consensys/web3signer` repository:
 
 ```bat
-git clone --recursive https://github.com/Consensys/web3signer.git
+git clone --recursive https://github.com/Consensys-Incorporated/web3signer.git
 ```
 
 ### Build Web3Signer

--- a/docs/get-started/install-binaries.md
+++ b/docs/get-started/install-binaries.md
@@ -21,10 +21,10 @@ Web3Signer requires Java 25 or later releases.
 
 ## Install binaries
 
-Download the Web3Signer [packaged binaries](https://github.com/Consensys/web3signer/releases/latest).
+Download the Web3Signer [packaged binaries](https://github.com/Consensys-Incorporated/web3signer/releases/latest).
 
 :::tip
-View the [**Releases** page](https://github.com/Consensys/web3signer/releases) to download a specific version.
+View the [**Releases** page](https://github.com/Consensys-Incorporated/web3signer/releases) to download a specific version.
 :::
 
 Unpack the downloaded files and change into the `web3signer-<release>` directory.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -20,7 +20,7 @@ const config = {
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
-  organizationName: "Consensys", // Usually your GitHub org/user name.
+  organizationName: "Consensys-Incorporated", // Usually your GitHub org/user name.
   projectName: "doc.web3signer", // Usually your repo name.
   deploymentBranch: "gh-pages", // Github Pages deploying branch
 
@@ -39,7 +39,7 @@ const config = {
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
           // Set a base path separate from default /docs
-          editUrl: "https://github.com/Consensys/doc.web3signer/tree/main/",
+          editUrl: "https://github.com/Consensys-Incorporated/doc.web3signer/tree/main/",
           path: "docs",
           routeBasePath: "/",
           breadcrumbs: true,
@@ -143,7 +143,7 @@ const config = {
             dropdownActiveClassDisabled: true,
           },
           {
-            href: "https://github.com/Consensys/web3signer",
+            href: "https://github.com/Consensys-Incorporated/web3signer",
             className: "header-github-link",
             "aria-label": "GitHub",
             title: "GitHub",
@@ -212,11 +212,11 @@ const config = {
               },
               {
                 label: "Web3Signer GitHub",
-                href: "https://github.com/Consensys/web3signer",
+                href: "https://github.com/Consensys-Incorporated/web3signer",
               },
               {
                 label: "Web3Signer documentation GitHub",
-                href: "https://github.com/Consensys/doc.web3signer",
+                href: "https://github.com/Consensys-Incorporated/doc.web3signer",
               },
             ],
           },

--- a/static/index.md
+++ b/static/index.md
@@ -35,4 +35,4 @@ slashing protection for consensus layer validator signing.
 ## Questions
 
 For questions about Web3Signer, use [GitHub Discussions](https://github.com/Consensys-Incorporated/web3signer/discussions) or open an issue in
-the [Web3Signer repository](https://github.com/Consensys/web3signer).
+the [Web3Signer repository](https://github.com/Consensys-Incorporated/web3signer).

--- a/versioned_docs/version-26.7.0/get-started/build-from-source.md
+++ b/versioned_docs/version-26.7.0/get-started/build-from-source.md
@@ -25,7 +25,7 @@ Web3Signer requires Java 25 or later releases.
 Clone the `Consensys/web3signer` repository:
 
 ```bash
-git clone --recursive https://github.com/Consensys/web3signer.git
+git clone --recursive https://github.com/Consensys-Incorporated/web3signer.git
 ```
 
 ### Build Web3Signer
@@ -68,7 +68,7 @@ bin/web3signer --help
 Clone the `Consensys/web3signer` repository:
 
 ```bat
-git clone --recursive https://github.com/Consensys/web3signer.git
+git clone --recursive https://github.com/Consensys-Incorporated/web3signer.git
 ```
 
 ### Build Web3Signer

--- a/versioned_docs/version-26.7.0/get-started/install-binaries.md
+++ b/versioned_docs/version-26.7.0/get-started/install-binaries.md
@@ -21,10 +21,10 @@ Web3Signer requires Java 25 or later releases.
 
 ## Install binaries
 
-Download the Web3Signer [packaged binaries](https://github.com/Consensys/web3signer/releases/latest).
+Download the Web3Signer [packaged binaries](https://github.com/Consensys-Incorporated/web3signer/releases/latest).
 
 :::tip
-View the [**Releases** page](https://github.com/Consensys/web3signer/releases) to download a specific version.
+View the [**Releases** page](https://github.com/Consensys-Incorporated/web3signer/releases) to download a specific version.
 :::
 
 Unpack the downloaded files and change into the `web3signer-<release>` directory.


### PR DESCRIPTION
## Summary

Updates stale GitHub organization references from `Consensys` to `Consensys-Incorporated`.
The changes cover the Docusaurus configuration, current and versioned installation docs, and repository links.

## Motivation

Resolves #400 so copy-paste clone commands and site links use the canonical organization rather than relying on GitHub redirects.

## Testing

Tested commit: `b68f5ae19b262159f9c4c1affa7f41535c12f78e`

- `npm ci`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm start -- --host 127.0.0.1 --port 3100` and `curl http://127.0.0.1:3100/` (HTTP 200)
- `git diff --check`

All commands passed. The legacy CLA workflow URL remains intentionally unchanged because it targets the separate CLA repository, not a Web3Signer source or documentation link.

## Checklist

- [x] Documentation updated
- [x] Reviewed repository contribution guidance

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and Docusaurus link/metadata only; no runtime or security behavior changes.
> 
> **Overview**
> Updates documentation and site configuration so GitHub links and Docusaurus metadata point at **`Consensys-Incorporated`** instead of **`Consensys`**, so clone commands, release downloads, edit links, and navbar/footer targets use the canonical org (addresses #400).
> 
> **`docusaurus.config.js`** changes `organizationName`, the docs **edit URL**, and header/footer links for the Web3Signer and doc repos. **README**, **AGENTS.md**, **static/index.md**, current **get-started** pages, and matching **version-26.7.0** copies get the same URL updates for clones and releases.
> 
> Prose in build-from-source still says ``Consensys/web3signer`` in headings while the commands use the new URL; the CLA workflow link to `github.com/Consensys/cla` is unchanged per the PR description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b68f5ae19b262159f9c4c1affa7f41535c12f78e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->