### PR TITLE
Stop indexing pre-release `/development `docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -62,6 +62,7 @@ const config = {
             current: {
               label: "development",
               path: "development",
+              noIndex: true,
             },
             //the last stable release in the versioned_docs/version-1.0
             "26.7.0": {
@@ -71,6 +72,9 @@ const config = {
         },
         theme: {
           customCss: require.resolve("./src/css/custom.css"),
+        },
+        sitemap: {
+          ignorePatterns: ["/development", "/development/**"],
         },
       },
     ],

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -62,7 +62,6 @@ const config = {
             current: {
               label: "development",
               path: "development",
-              noIndex: true,
             },
             //the last stable release in the versioned_docs/version-1.0
             "26.7.0": {


### PR DESCRIPTION
Search and AI crawlers were treating unreleased features as current. Both stable and development content are listed in the sitemap. Omit /development from the sitemap.

## Summary

- Stops AI crawlers from treating pre-release `/development/` docs as current.
- Omits `/development` and `/development/**` from `sitemap.xml`. Stable pages at the site root are unchanged.
- Leaves the version dropdown in place so development docs stay reachable on purpose.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation build/SEO configuration only; no application logic, auth, or data handling changes.
> 
> **Overview**
> Pre-release documentation under **`/development`** was still listed in **`sitemap.xml`**, so search and AI crawlers could treat unreleased content as current alongside stable docs at the site root.
> 
> This PR adds **`sitemap.ignorePatterns`** for **`/development`** and **`/development/**`** in the Docusaurus classic preset. **Stable URLs stay in the sitemap**; the development version dropdown and on-site links are unchanged—only sitemap discovery is limited.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02010174f749544391acf764c436721c2ff08472. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->